### PR TITLE
ESLG-55: Implemented saving the end time and score of the game to sessionStorage

### DIFF
--- a/apps/client/public/assets/basketball/play.html
+++ b/apps/client/public/assets/basketball/play.html
@@ -69,11 +69,13 @@
       var leftRimSprite, rightRimSprite, frontRimSprite, ballSprite
       var scoreSound, rimHitSound, throwSound, spawnSound, buzzerSound
       var collisionGroup
-      var timeLeft,
-        score = 0,
+      var score = 0,
         scoreText,
         timeLeftText,
-        gameIsOver = false
+        gameIsOver = false,
+        endTime, // time in millis that signifies the end of the game when hit
+        timeLeft = 0,
+        timeExpired = false // turns to true when timeLeft gets to 0
       var digital7Loaded
       var bgImageScale
 
@@ -135,8 +137,6 @@
         )
         scoreText.visible = false
 
-        timeLeft = game.time.create(false)
-        timeLeft.start()
         timeLeftText = game.add.text(0, 0, '', {
           font: 'Digital-7 Mono',
           fontSize: `${gameParams.digitsFontSize}px`,
@@ -161,20 +161,43 @@
         rightRimSprite.body.setCollisionGroup(collisionGroup)
         rightRimSprite.body.collides([collisionGroup])
 
-        createBall()
-
         cursors = game.input.keyboard.createCursorKeys()
 
         game.input.onDown.add(click, this)
         game.input.onUp.add(release, this)
+
+        const existingEndTime = sessionStorage.getItem('endTime')
+        if (existingEndTime) {
+          endTime = existingEndTime
+          const now = new Date()
+          if (now.getTime() >= endTime) {
+            gameOver()
+          }
+        }
+
+        const existingScore = sessionStorage.getItem('score')
+        if (existingScore) {
+          score = Number(existingScore)
+        }
+
+        createBall()
+      }
+
+      function timerStart() {
+        const now = new Date()
+        endTime = now.getTime() + TIME
+        sessionStorage.setItem('endTime', endTime)
       }
 
       function timesUp() {
-        playSound(buzzerSound)
         if (!ballSprite.launched) {
           ballSprite.kill()
         }
-        gameOver()
+        if (gameParams.playAudio) {
+          playSound(buzzerSound)
+        } else {
+          gameOver()
+        }
       }
 
       function update() {
@@ -197,20 +220,26 @@
           ) {
             score += 1
             playSound(scoreSound)
+            sessionStorage.setItem('score', score)
           }
+        }
+
+        const now = new Date()
+        timeLeft = endTime > now.getTime() ? endTime - now.getTime() : 0
+        if (timeLeft == 0 && endTime && !timeExpired) {
+          timeExpired = true
+          timesUp()
         }
 
         if (ballSprite && ballSprite.body.y > gameParams.ballDeadEnd) {
           game.physics.p2.gravity.y = 0
           ballSprite.kill()
-          if (timeLeft.duration > 0) {
+          if (timeLeft > 0) {
             createBall()
-          } else {
-            gameOver()
           }
         }
 
-        timeLeftText.text = Math.ceil(timeLeft.duration.toFixed(0) / 1000)
+        timeLeftText.text = Math.ceil(timeLeft / 1000)
         scoreText.text = score
 
         // Mostly used for loading our custom font for the first time
@@ -301,7 +330,7 @@
       }
 
       function launch(x_traj) {
-        if (ballSprite.launched === false && !timeLeft.expired) {
+        if (ballSprite.launched === false && !timeExpired) {
           ballSprite.body.setCircle((120 * (ballSprite.scale.x * 0.6)) / 2) // 120 is the size of the ball image
           ballSprite.body.setCollisionGroup(collisionGroup)
           ballSprite.launched = true
@@ -323,8 +352,9 @@
           ballSprite.body.rotateRight(x_traj / gameParams.ballSpinRate)
           playSound(throwSound)
 
-          if (timeLeft.duration <= 0) {
-            timeLeft.add(TIME, timesUp, this)
+          // if endTime is not yet set, start the timer
+          if (!endTime) {
+            timerStart()
           }
         }
       }
@@ -336,19 +366,14 @@
       }
 
       function gameOver() {
-        if (
-          (buzzerSound && buzzerSound.isPlaying) ||
-          (ballSprite && ballSprite.alive) ||
-          gameIsOver
-        ) {
+        if ((ballSprite && ballSprite.alive) || gameIsOver) {
           return
         }
         gameIsOver = true
-        console.log('Game Over. Final Score is ' + score)
         window.location.href = '/basketball/rewards-message'
         // TODO
-        // set localStorage value for the final points
-        // redirect to rewards page
+        // remove line below for production
+        sessionStorage.removeItem('endTime')
       }
 
       function computeGameParams() {


### PR DESCRIPTION
## Description
- Removed usage of Phaser library-provided timer and implemented native timer from vanilla Javascript date library instead
- Added code that saves the end time and score of the game to sessionStorage at appropriate times and code to retrieve it on game load

## Screenshots
![2022-09-29 21-29-26 (online-video-cutter com)](https://user-images.githubusercontent.com/29355973/193046396-6c930316-afbe-498d-b87b-6989d1e93e7e.gif)
GIF does not represent the actual speed of the game

## Checklist

- [x] I've prefixed my PR title with the Jira ticket number (e.g. PROJ-123: fix server logging)
- [x] I've reviewed the code by going over this PR
- [x] I've added comments to any parts of the code, where applicable, that would help provide context to a reviewer
- [ ] I've added a few unit tests and/or I've added data-test-ids where appropriate
- [ ] I've run the e2e tests locally to confirm it doesn't break them
